### PR TITLE
Javatools launcher crosscompile

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,12 @@
+# Directory: ./.github/ #
+
+This directory used by [GitHub](https://github.com/), holds data necessary 
+for different services provided by them. The files in this directory and its 
+subdirectories have no effect on the project. They only affect how GitHub 
+handles the repository, and the automated actions that GitHub performs.
+
+Folder: `./workflows/`  
+This folder contains workflow files. These files describe a Github Actions 
+[workflow](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow).
+These are helpful for continuous integration and automated testing among other things. 
+

--- a/.github/_README.md
+++ b/.github/_README.md
@@ -1,5 +1,8 @@
 # Directory: ./.github/ #
 
+***WARNING: DO NOT CHANGE THE FILENAME!*** If this file is called `README.md`, 
+github shows this file instead of the intended `xvm/README.md`.
+
 This directory used by [GitHub](https://github.com/), holds data necessary 
 for different services provided by them. The files in this directory and its 
 subdirectories have no effect on the project. They only affect how GitHub 

--- a/.github/workflows/javatools_launcher-compile.yml
+++ b/.github/workflows/javatools_launcher-compile.yml
@@ -1,0 +1,51 @@
+name: javatools_launcher compile
+
+# This section ("on") defines which events should trigger this workflow to run
+on:
+  # Pushing to these branches triggers the workflow to run
+  push: 
+    # javatools-crosscompile branch is only in this list for testing purposes
+    branches: [ master, javatools-crosscompile ] 
+    # But only if there is a change in a file in this path
+    paths: 
+      - javatools_launcher/src/main/c/
+  
+  # Pullrequests triggers the  script the same way as a push except it only works on master
+  pull_request:
+    branches: [ master ]
+    paths: 
+      - javatools_launcher/src/main/c/
+
+jobs:
+  build:
+    # This defines the OS to run this workflow on. 
+    # ${{matrix.os}} is a way to define the OS as being one of those defined in the matrix section.
+    runs-on: ${{matrix.os}}
+    strategy:
+      # Here the operating systems used are defined.
+      # Each OS defines the MAKE_OS variable to use when compiling.
+      matrix: 
+        include:
+          - os: ubuntu-latest
+            MAKE_OS: linux
+            
+          - os: windows-latest
+            MAKE_OS: windows
+            
+          - os: macos-latest
+            MAKE_OS: macos
+
+ 
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make OS_NAME=${{matrix.MAKE_OS}} -o javatools/build/exe/${{matrix.MAKE_OS}}_launcher -C javatools/src/main/c/
+
+      # I'm unsure if theese parts are required, leeveng them out until testing is possible
+   # - name: make check
+   #   run: make check
+   # - name: make distcheck
+   #   run: make distcheck

--- a/.github/workflows/javatools_launcher-compile.yml
+++ b/.github/workflows/javatools_launcher-compile.yml
@@ -10,11 +10,18 @@ on:
     paths: 
       - javatools_launcher/src/main/c/
   
-  # Pullrequests triggers the  script the same way as a push except it only works on master
+  # Pull requests triggers the  script the same way as a push except it only works on master
   pull_request:
     branches: [ master ]
     paths: 
       - javatools_launcher/src/main/c/
+
+  # This is a hook for manually activating the workflow
+  # It can be activated in two ways
+  #   - Click the "run workflow" button in github
+  #   - @see <a href="https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event">
+  #     Send a post request to the web hook<a/>
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
GitHub actions aren't showing up as expected. This pull request is meant mainly for testing if including the workflow on the main branch solves the problem.